### PR TITLE
Warn about unencrypted attachments

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+
+webapp:
+* warn about unencrypted attachments limitation
+
 0.9.1 (19/05/2022)
 -----
 

--- a/webapp/src/hooks.tsx
+++ b/webapp/src/hooks.tsx
@@ -316,7 +316,9 @@ export default class E2EEHooks {
                 for (const [userID, _] of newPubkeys) {
                     msg += ' @' + getUser(this.store.getState(), userID).username;
                 }
+
                 this.sendEphemeralPost(msg, chanID);
+                this.sendEphemeralPost('(attachments are not encrypted and are sent in plaintext)', chanID);
             }
             await storeChannelPubkeys(chanID, pubkeyValues);
 


### PR DESCRIPTION
Attachments are not encrypted in the Mattermost E2EE plugin model, due to current limitations.

This is left implicit and users may by mistake share sensitive information as plaintext through attachments.

This PR adds an ephemeral system message warning about that.